### PR TITLE
Ported the original 5-combine.sh bash script to python for faster exe…

### DIFF
--- a/bin/find-min-rmse.py
+++ b/bin/find-min-rmse.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+#Author: Matthias Vogler
+
+import numpy as np
+import sys
+import os
+
+def usage():
+	print("Usage: python3 find-min-rmse.py <ROOT> <BINDIR> <FRAGDIR> <WORKDIR> <NFRAGS> <NFIT> <MINCHGS> <MAXCHGS> <MINFRAGCHGS> <MAXFRAGCHGS>")
+
+
+if len(sys.argv) < 11:
+	usage()
+	exit()
+
+ROOT = str(sys.argv[1])
+BINDIR = str(sys.argv[2])
+FRAGDIR = str(sys.argv[3])
+WORKDIR = str(sys.argv[4])
+nfrag = int(sys.argv[5])
+nfit = int(sys.argv[6])
+minchgs = int(sys.argv[7])
+maxchgs = int(sys.argv[8]) + 1
+minfragchgs = int(sys.argv[9])
+maxfragchgs = int(sys.argv[10])
+
+
+
+def read_rmse(nfrag, nfit, minfragchgs, maxfragchgs):
+	rmse_data = np.zeros([nfrag, maxfragchgs - minfragchgs + 1, nfit])
+	for ifrag in range(0, nfrag):
+		for ifit in range(0, nfit):
+			for ichgs in range(0, maxfragchgs+1 - minfragchgs):
+				xyzfile = ROOT + "/4-fit-frags/frag" + str(ifrag+1) + "/fit" + str(ifit+1) + "/" + str(ichgs+minfragchgs) + "charges.xyz"
+				#print(xyzfile)
+				try:
+					with open(xyzfile, 'r') as file:
+						data = file.read().replace('\n', ' ').partition("RMSE")
+						data = data[2].partition("kcal/mol")
+						data = data[0].strip()
+					rmse_data[ifrag, ichgs, ifit] = float(data)
+				except FileNotFoundError as e:
+					print("ERROR:" + xyzfile + " does not exist! \n Skipping...")
+					rmse_data[ifrag, ichgs, ifit] = 1000.0
+	return rmse_data
+
+
+def combine_frags(nfrag, nfit, fit_vec, perm_vec, fragdir, BINDIR):
+	base = "python3 " + BINDIR + "/combine-frags.py "
+	string = ""
+	for ifrag in range(0, nfrag):
+		string += fragdir + "/frag" + str(ifrag+1) + "/fit" + str(int(fit_vec[ifrag] + 1)) + "/" + str(int(perm_vec[ifrag])) + "charges.xyz "
+	return base + string
+
+
+rmse_data = read_rmse(nfrag, nfit, minfragchgs, maxfragchgs)
+
+#print(combine_frags(4, 3, [0, 2, 1, 0], [5, 4, 4, 4], fragdir))
+
+
+for i in range(minchgs, maxchgs):
+	os.system("python3 " + BINDIR + "/charge-permutations.py " + str(nfrag) + " " + str(i) + " " + str(minfragchgs) + " " + str(maxfragchgs) + " > permutations-" + str(i) + ".dat")
+	if os.stat("permutations-" + str(i) + ".dat").st_size != 0:
+		perm = np.loadtxt("permutations-" + str(i) + ".dat")
+		nperm = perm.shape[0]
+		best_rmse = 99999.0
+		rmse_perm = np.zeros(nperm)
+		fit_index = np.zeros([nfrag, nperm])
+		for iperm in range(0, nperm):
+			rmse_avg = 0.0
+			for ifrag in range(0, nfrag):
+				rmse = 99999.0
+				for ifit in range(0, nfit):
+					try:
+						rmse_curr = rmse_data[ifrag, int(perm[iperm, ifrag]-minfragchgs), ifit]
+					except IndexError as e:
+						rmse_curr = rmse_data[ifrag, int(perm[iperm]-minfragchgs), ifit]
+					if rmse_curr < rmse:
+						rmse = rmse_curr
+						fit_index[ifrag, iperm] = ifit
+				rmse_avg += rmse
+			rmse_perm[iperm] = rmse_avg/nfrag
+		try:
+			print("Found minimal solution with RMSE: " np.min(rmse_perm))
+			os.system(combine_frags(nfrag, nfit, fit_index[:, np.argmin(rmse_perm)], perm[np.argmin(rmse_perm), :], FRAGDIR, BINDIR))
+		except IndexError as e:
+			print("Found minimal solution with RMSE: " np.min(rmse_perm))
+			os.system(combine_frags(nfrag, nfit, fit_index[:, np.argmin(rmse_perm)], perm, FRAGDIR, BINDIR))		
+		os.system("mv combined.xyz "+ WORKDIR + "/" + str(int(i)) + "-combined.xyz")
+		os.system("rm permutations-" + str(i) + ".dat")
+	else:
+		print("WARNING: NO SOLUTION FOUND FOR " + str(i) + " charges!")
+		os.system("rm permutations-" + str(i) + ".dat")
+
+
+
+
+	
+
+	

--- a/examples/naptha/5-combine-frags/5-combine.sh
+++ b/examples/naptha/5-combine-frags/5-combine.sh
@@ -3,8 +3,6 @@
 # Script to find the best combination of fragment results that combine to a given number
 # of molecule charges
 
-# TODO: slow for larger systems with many permutations - should rather read all
-# RMSE values into memory at start and find best RMSE using e.g. Python rather than BASH
 
 # FOLDERS
 ROOT=/home/devereux/MDCM-git/examples/naptha
@@ -19,48 +17,5 @@ MAXCHGS=64          #maximum number of charges for whole molecule
 MINFRAGCHGS=6       #minimum charges used to fit fragments in previous step
 MAXFRAGCHGS=14      #maximum charges used to fit fragments in previous step
 
-cd $FRAGDIR
 
-for ((i=$MINCHGS; i<=$MAXCHGS; i++)); do
-
-  # get all permutations that add up to $i using $NFRAG terms
-  $BINDIR/charge-permutations.py $NFRAG $i $MINFRAGCHGS $MAXFRAGCHGS > permutations-${i}.dat
-  nperm=$(sed -n $= permutations-${i}.dat)
-  [ -z $nperm ] && echo "Warning, no solution for $i charges" && continue
-  best_rmse=999999
-  for ((j=1; j<=$nperm; j++)); do
-    perm=$(sed -n ${j}p permutations-${i}.dat)
-    for ((k=1; k<=$NFRAG; k++)); do
-      nchg[$k]=$(echo $perm | awk "{print \$${k}}")
-      rmse[$k]=999999
-      for ((l=1; l<=$NFIT; l++)); do
-        if [ -e $FRAGDIR/frag$k/fit$l/${nchg[$k]}charges.xyz ]; then
-          trmse=$(grep RMSE $FRAGDIR/frag$k/fit$l/${nchg[$k]}charges.xyz | awk '{print $2}' | sed "s/E/*10^/g" | sed "s/+//g")
-          if (( $(echo "$trmse < ${rmse[$k]}" | bc -l) )); then
-            rmse[$k]=$trmse
-            best[$k]=$l
-            fragfile[$k]=$FRAGDIR/frag$k/fit$l/${nchg[$k]}charges.xyz
-          fi
-        fi
-      done
-    done
-    fraglist=""
-    mean_rmse=0
-    for ((k=1; k<=$NFRAG; k++)); do
-      mean_rmse=$(echo "$mean_rmse + ${rmse[$k]}" | bc -l)
-      fraglist="$fraglist ${fragfile[$k]}"
-    done
-    mean_rmse=$(echo "$mean_rmse / $NFRAG" | bc -l)
-    echo "$i chgs permutation $perm rmse=$mean_rmse"
-    if (( $(echo "$mean_rmse < $best_rmse" | bc -l) )); then
-      best_rmse=$mean_rmse
-      echo "NEW BEST $i charges: $perm rmse = $mean_rmse"
-      $BINDIR/combine-frags.py $fraglist
-      echo >> combined.xyz
-      echo "total molecule built from fragment files: $fraglist" >> combined.xyz
-      mv combined.xyz $WORKDIR/$i-combined.xyz
-    fi
-  done
-  rm permutations-${i}.dat
-
-done
+$BINDIR/find-min-rmse.py $ROOT $BINDIR $FRAGDIR $WORKDIR $NFRAG $NFIT $MINCHGS $MAXCHGS $MINFRAGCHGS $MAXFRAGCHGS


### PR DESCRIPTION
…cution.

Additions:
- find-min-rmse.py: python script that goes trough the frag directories and combines the ones with the lowest RMSE
Changes:
- examples/naptha/5-combine-frags/5-combine.sh: Changed the bash script to execute find-min-rmse.py

The bottleneck in performance now seems to be the generation of permutations (charge-permutations.py) especially for larger fragment numbers (6+).